### PR TITLE
Add missing methods dependency to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Imports:
+    methods,
     Rcpp (>= 0.12.5),
     RProtoBuf,
     futile.logger


### PR DESCRIPTION
## Summary
- add the base methods package to the Imports list so R CMD check sees the namespace dependency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d6a5e168988323866beb26426d8c21