### PR TITLE
Fix insecure channel credential creation for newer gRPC

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -53,7 +53,8 @@ RawVector fetch(CharacterVector server, CharacterVector method, RawVector reques
   const grpc_slice *sp = &server_slice;
     
   grpc_channel *channel = NULL;
-  grpc_channel_credentials *insecure_creds = grpc_insecure_credentials_create();
+  grpc_channel_credentials *insecure_creds =
+      grpc_insecure_channel_credentials_create();
   if (insecure_creds == NULL) {
     stop("Failed to create insecure channel credentials");
   }

--- a/src/ext/channel.cc
+++ b/src/ext/channel.cc
@@ -180,7 +180,7 @@ NAN_METHOD(Channel::New) {
     }
     if (creds == NULL) {
       grpc_channel_credentials *insecure_creds =
-          grpc_insecure_credentials_create();
+          grpc_insecure_channel_credentials_create();
       if (insecure_creds == NULL) {
         DeallocateChannelArgs(channel_args_ptr);
         return Nan::ThrowError("Failed to create insecure channel credentials");


### PR DESCRIPTION
## Summary
- replace deprecated `grpc_insecure_credentials_create` calls with the modern insecure channel credential factory
- keep client and Node channel code building against newer gRPC releases

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d6aa0123388323bc937f342ec3564f