### PR TITLE
Add fallback for insecure channel creation

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -53,6 +53,7 @@ RawVector fetch(CharacterVector server, CharacterVector method, RawVector reques
   const grpc_slice *sp = &server_slice;
     
   grpc_channel *channel = NULL;
+#ifdef GRPC_SECURITY_SUPPORTS_CLIENT_CHANNEL_CREDS
   grpc_channel_credentials *insecure_creds =
       grpc_insecure_channel_credentials_create();
   if (insecure_creds == NULL) {
@@ -61,6 +62,9 @@ RawVector fetch(CharacterVector server, CharacterVector method, RawVector reques
 
   channel = grpc_channel_create(server[0], insecure_creds, NULL);
   grpc_channel_credentials_release(insecure_creds);
+#else
+  channel = grpc_insecure_channel_create(server[0], NULL, NULL);
+#endif
 
   if (channel == NULL) {
     stop("Failed to create gRPC channel");

--- a/src/ext/channel.cc
+++ b/src/ext/channel.cc
@@ -179,6 +179,7 @@ NAN_METHOD(Channel::New) {
           "string keys and integer or string values");
     }
     if (creds == NULL) {
+#ifdef GRPC_SECURITY_SUPPORTS_CLIENT_CHANNEL_CREDS
       grpc_channel_credentials *insecure_creds =
           grpc_insecure_channel_credentials_create();
       if (insecure_creds == NULL) {
@@ -188,6 +189,10 @@ NAN_METHOD(Channel::New) {
       wrapped_channel =
           grpc_channel_create(*host, insecure_creds, channel_args_ptr);
       grpc_channel_credentials_release(insecure_creds);
+#else
+      wrapped_channel =
+          grpc_insecure_channel_create(*host, channel_args_ptr, NULL);
+#endif
     } else {
       wrapped_channel =
           grpc_secure_channel_create(creds, *host, channel_args_ptr, NULL);


### PR DESCRIPTION
## Summary
- add a compile-time fallback for creating gRPC channels when channel credentials APIs are unavailable
- mirror the fallback in the Node channel bindings to keep behavior consistent

## Testing
- not run (gRPC development libraries are unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_b_68d6ce8451388323a855b46b506b3d24