### PR TITLE
Set package build to use C++17

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
-CXX_STD = CXX11
+CXX_STD = CXX17
 PKG_LIBS = `pkg-config --libs grpc`
 PKG_CXXFLAGS = `pkg-config --cflags grpc`
 


### PR DESCRIPTION
## Summary
- update the package makefile to request C++17 so grpc and abseil headers compile

## Testing
- ❌ `R CMD build .` (fails: R is not available in the container)


------
https://chatgpt.com/codex/tasks/task_b_68d8102e84308323ad554b3f98d2adb1