### PR TITLE
Fix insecure channel creation with current gRPC releases

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -2,18 +2,9 @@
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 
-#if defined(__has_include)
-#if __has_include(<grpc/credentials.h>)
-#include <grpc/credentials.h>
-#define RGRPC_HAVE_GRPC_INSECURE_CREDENTIALS 1
-#endif
-#endif
 #include <grpc/impl/codegen/byte_buffer_reader.h>
 #include <grpc/slice.h>
 
-#ifndef GRPC_HAVE_GRPC_CHANNEL_CREATE
-#define GRPC_HAVE_GRPC_CHANNEL_CREATE 1
-#endif
 
 #include <cstring>
 #include <vector>
@@ -64,7 +55,7 @@ RawVector fetch(CharacterVector server, CharacterVector method, RawVector reques
   const grpc_slice *sp = &server_slice;
     
   grpc_channel *channel = NULL;
-#if defined(RGRPC_HAVE_GRPC_INSECURE_CREDENTIALS)
+
   grpc_channel_credentials *insecure_creds =
       grpc_insecure_credentials_create();
   if (insecure_creds == NULL) {
@@ -73,20 +64,6 @@ RawVector fetch(CharacterVector server, CharacterVector method, RawVector reques
 
   channel = grpc_channel_create(server[0], insecure_creds, NULL);
   grpc_channel_credentials_release(insecure_creds);
-#elif defined(GRPC_SECURITY_SUPPORTS_CLIENT_CHANNEL_CREDS)
-  grpc_channel_credentials *insecure_creds =
-      grpc_insecure_channel_credentials_create();
-  if (insecure_creds == NULL) {
-    stop("Failed to create insecure channel credentials");
-  }
-
-  channel = grpc_channel_create(server[0], insecure_creds, NULL);
-  grpc_channel_credentials_release(insecure_creds);
-#elif GRPC_HAVE_GRPC_CHANNEL_CREATE
-  channel = grpc_insecure_channel_create(server[0], NULL, NULL);
-#else
-#error "gRPC insecure channel helpers are unavailable. Verify your toolchain provides grpc_insecure_credentials_create(), grpc_insecure_channel_credentials_create() or grpc_insecure_channel_create(); consult grpc_version_string() for supported releases."
-#endif
 
   if (channel == NULL) {
     stop("Failed to create gRPC channel");


### PR DESCRIPTION
## Summary
- build the client channel using `grpc_insecure_credentials_create()` so the package compiles with modern gRPC headers
- drop legacy fallbacks that depended on the removed `grpc_insecure_channel_create()` helper

## Testing
- R CMD INSTALL grpc_0.2.0.tar.gz

------
https://chatgpt.com/codex/tasks/task_b_68d849a750b483239dfa70946148703b