### PR TITLE
Avoid direct use of gpr_inf_future

### DIFF
--- a/src/ext/timeval.cc
+++ b/src/ext/timeval.cc
@@ -23,14 +23,36 @@
 #include "grpc/support/time.h"
 #include "timeval.h"
 
+namespace {
+constexpr int32_t kNanosPerSecond = 1000000000;
+constexpr int32_t kMaxFiniteNanos = kNanosPerSecond - 1;
+
+gpr_timespec MakeInfiniteTimespec(bool future, gpr_clock_type clock_type) {
+  gpr_timespec result;
+  result.clock_type = clock_type;
+  result.tv_sec = future ? std::numeric_limits<int64_t>::max()
+                         : std::numeric_limits<int64_t>::min();
+  result.tv_nsec = future ? kMaxFiniteNanos : -kMaxFiniteNanos;
+  return result;
+}
+}  // namespace
+
 namespace grpc {
 namespace node {
 
+gpr_timespec InfiniteFutureTimespec(gpr_clock_type clock_type) {
+  return MakeInfiniteTimespec(true, clock_type);
+}
+
+gpr_timespec InfinitePastTimespec(gpr_clock_type clock_type) {
+  return MakeInfiniteTimespec(false, clock_type);
+}
+
 gpr_timespec MillisecondsToTimespec(double millis) {
   if (millis == std::numeric_limits<double>::infinity()) {
-    return gpr_inf_future(GPR_CLOCK_REALTIME);
+    return InfiniteFutureTimespec(GPR_CLOCK_REALTIME);
   } else if (millis == -std::numeric_limits<double>::infinity()) {
-    return gpr_inf_past(GPR_CLOCK_REALTIME);
+    return InfinitePastTimespec(GPR_CLOCK_REALTIME);
   } else {
     return gpr_time_from_micros(static_cast<int64_t>(millis * 1000),
                                 GPR_CLOCK_REALTIME);
@@ -39,9 +61,10 @@ gpr_timespec MillisecondsToTimespec(double millis) {
 
 double TimespecToMilliseconds(gpr_timespec timespec) {
   timespec = gpr_convert_clock_type(timespec, GPR_CLOCK_REALTIME);
-  if (gpr_time_cmp(timespec, gpr_inf_future(GPR_CLOCK_REALTIME)) == 0) {
+  if (gpr_time_cmp(timespec, InfiniteFutureTimespec(GPR_CLOCK_REALTIME)) == 0) {
     return std::numeric_limits<double>::infinity();
-  } else if (gpr_time_cmp(timespec, gpr_inf_past(GPR_CLOCK_REALTIME)) == 0) {
+  } else if (gpr_time_cmp(timespec, InfinitePastTimespec(GPR_CLOCK_REALTIME)) ==
+             0) {
     return -std::numeric_limits<double>::infinity();
   } else {
     return (static_cast<double>(timespec.tv_sec) * 1000 +

--- a/src/ext/timeval.h
+++ b/src/ext/timeval.h
@@ -26,6 +26,8 @@ namespace node {
 
 double TimespecToMilliseconds(gpr_timespec time);
 gpr_timespec MillisecondsToTimespec(double millis);
+gpr_timespec InfiniteFutureTimespec(gpr_clock_type clock_type);
+gpr_timespec InfinitePastTimespec(gpr_clock_type clock_type);
 
 }  // namespace node
 }  // namespace grpc

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -7,6 +7,7 @@
 #endif
 #include <grpc/grpc_security.h>
 #include <grpc/impl/codegen/byte_buffer_reader.h>
+#include "ext/timeval.h"
 #include "common.h"
 #include <string>
 #include <grpc/slice.h>
@@ -324,10 +325,11 @@ List run(List target, CharacterVector hoststring, List hooks) {
   //shutdown
   RGRPC_LOG("Shutting down\n");
   runFunctionIfProvided(hooks, "shutdown", params);
-  grpc_server_shutdown_and_notify(server, queue, 0 /* tag */);
-  grpc_server_cancel_all_calls(server);
-  grpc_completion_queue_next(queue, gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
-  grpc_server_destroy(server);
+    grpc_server_shutdown_and_notify(server, queue, 0 /* tag */);
+    grpc_server_cancel_all_calls(server);
+    grpc_completion_queue_next(
+        queue, grpc::node::InfiniteFutureTimespec(GPR_CLOCK_REALTIME), NULL);
+    grpc_server_destroy(server);
   RGRPC_LOG("[STOPPED]");
   runFunctionIfProvided(hooks, "stopped", params);  
 


### PR DESCRIPTION
## Summary
- add internal helpers to construct infinite future/past gpr_timespec values without relying on gpr_inf_* exports
- update time conversion helpers to use the new constructors
- switch server shutdown polling to the new helper to avoid unresolved symbols at load time

## Testing
- not run (R toolchain and gRPC libraries are unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_b_68d97b23ce64832395a745f1f408d78b