### PR TITLE
Use gpr_inf_future for completion queue shutdown

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -7,6 +7,7 @@
 #endif
 #include <grpc/grpc_security.h>
 #include <grpc/impl/codegen/byte_buffer_reader.h>
+#include <grpc/support/time.h>
 #include "ext/timeval.h"
 #include "common.h"
 #include <string>
@@ -327,8 +328,7 @@ List run(List target, CharacterVector hoststring, List hooks) {
   runFunctionIfProvided(hooks, "shutdown", params);
     grpc_server_shutdown_and_notify(server, queue, 0 /* tag */);
     grpc_server_cancel_all_calls(server);
-    grpc_completion_queue_next(
-        queue, grpc::node::InfiniteFutureTimespec(GPR_CLOCK_REALTIME), NULL);
+    grpc_completion_queue_next(queue, gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
     grpc_server_destroy(server);
   RGRPC_LOG("[STOPPED]");
   runFunctionIfProvided(hooks, "stopped", params);  


### PR DESCRIPTION
## Summary
- include grpc/support/time.h in the server implementation
- use gpr_inf_future to provide the shutdown deadline when draining the completion queue

## Testing
- `R CMD INSTALL --no-multiarch --with-keep.source .` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_b_68d97eb77fe48323b7a5f7035d6df991