### PR TITLE
Fix completion queue shutdown timeout for macOS

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -328,7 +328,8 @@ List run(List target, CharacterVector hoststring, List hooks) {
   runFunctionIfProvided(hooks, "shutdown", params);
     grpc_server_shutdown_and_notify(server, queue, 0 /* tag */);
     grpc_server_cancel_all_calls(server);
-    grpc_completion_queue_next(queue, gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
+    grpc_completion_queue_next(
+        queue, grpc::node::InfiniteFutureTimespec(GPR_CLOCK_REALTIME), NULL);
     grpc_server_destroy(server);
   RGRPC_LOG("[STOPPED]");
   runFunctionIfProvided(hooks, "stopped", params);  


### PR DESCRIPTION
## Summary
- replace the use of gpr_inf_future in the server shutdown path with the vendored InfiniteFutureTimespec helper to avoid missing symbols on macOS

## Testing
- not run (R is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_b_68d9827c06d08323804e774c82f8946e