### PR TITLE
Provide local clock conversion helper

### DIFF
--- a/src/ext/timeval.cc
+++ b/src/ext/timeval.cc
@@ -27,6 +27,31 @@ namespace {
 constexpr int32_t kNanosPerSecond = 1000000000;
 constexpr int32_t kMaxFiniteNanos = kNanosPerSecond - 1;
 
+gpr_timespec ConvertClockType(gpr_timespec t, gpr_clock_type clock_type) {
+  if (t.clock_type == clock_type) {
+    return t;
+  }
+
+  const auto kInt64Max = std::numeric_limits<int64_t>::max();
+  const auto kInt64Min = std::numeric_limits<int64_t>::min();
+
+  if (t.tv_sec == kInt64Max || t.tv_sec == kInt64Min) {
+    t.clock_type = clock_type;
+    return t;
+  }
+
+  if (clock_type == GPR_TIMESPAN) {
+    return gpr_time_sub(t, gpr_now(t.clock_type));
+  }
+
+  if (t.clock_type == GPR_TIMESPAN) {
+    return gpr_time_add(gpr_now(clock_type), t);
+  }
+
+  return gpr_time_add(gpr_now(clock_type),
+                      gpr_time_sub(t, gpr_now(t.clock_type)));
+}
+
 gpr_timespec MakeInfiniteTimespec(bool future, gpr_clock_type clock_type) {
   gpr_timespec result;
   result.clock_type = clock_type;
@@ -60,7 +85,7 @@ gpr_timespec MillisecondsToTimespec(double millis) {
 }
 
 double TimespecToMilliseconds(gpr_timespec timespec) {
-  timespec = gpr_convert_clock_type(timespec, GPR_CLOCK_REALTIME);
+  timespec = ConvertClockType(timespec, GPR_CLOCK_REALTIME);
   if (gpr_time_cmp(timespec, InfiniteFutureTimespec(GPR_CLOCK_REALTIME)) == 0) {
     return std::numeric_limits<double>::infinity();
   } else if (gpr_time_cmp(timespec, InfinitePastTimespec(GPR_CLOCK_REALTIME)) ==

--- a/src/timeval.cpp
+++ b/src/timeval.cpp
@@ -8,6 +8,31 @@ namespace {
 constexpr int32_t kNanosPerSecond = 1000000000;
 constexpr int32_t kMaxFiniteNanos = kNanosPerSecond - 1;
 
+gpr_timespec ConvertClockType(gpr_timespec t, gpr_clock_type clock_type) {
+  if (t.clock_type == clock_type) {
+    return t;
+  }
+
+  const auto kInt64Max = std::numeric_limits<int64_t>::max();
+  const auto kInt64Min = std::numeric_limits<int64_t>::min();
+
+  if (t.tv_sec == kInt64Max || t.tv_sec == kInt64Min) {
+    t.clock_type = clock_type;
+    return t;
+  }
+
+  if (clock_type == GPR_TIMESPAN) {
+    return gpr_time_sub(t, gpr_now(t.clock_type));
+  }
+
+  if (t.clock_type == GPR_TIMESPAN) {
+    return gpr_time_add(gpr_now(clock_type), t);
+  }
+
+  return gpr_time_add(gpr_now(clock_type),
+                      gpr_time_sub(t, gpr_now(t.clock_type)));
+}
+
 gpr_timespec MakeInfiniteTimespec(bool future, gpr_clock_type clock_type) {
   gpr_timespec result;
   result.clock_type = clock_type;
@@ -41,7 +66,7 @@ gpr_timespec MillisecondsToTimespec(double millis) {
 }
 
 double TimespecToMilliseconds(gpr_timespec timespec) {
-  timespec = gpr_convert_clock_type(timespec, GPR_CLOCK_REALTIME);
+  timespec = ConvertClockType(timespec, GPR_CLOCK_REALTIME);
   if (gpr_time_cmp(timespec, InfiniteFutureTimespec(GPR_CLOCK_REALTIME)) == 0) {
     return std::numeric_limits<double>::infinity();
   } else if (gpr_time_cmp(timespec, InfinitePastTimespec(GPR_CLOCK_REALTIME)) ==


### PR DESCRIPTION
## Summary
- add an internal gpr_timespec clock conversion helper mirroring legacy behavior
- replace calls to gpr_convert_clock_type with the local helper to avoid missing symbols at runtime

## Testing
- R CMD INSTALL . *(fails: R not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d98f6fa5f4832399793c89beada150